### PR TITLE
009 product search

### DIFF
--- a/e-commerce-project-study.git/cms/order-api/build.gradle
+++ b/e-commerce-project-study.git/cms/order-api/build.gradle
@@ -33,6 +33,13 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     implementation 'org.springframework.data:spring-data-envers'
     implementation 'org.hibernate:hibernate-envers:6.4.4.Final'
+
+    //querydsl
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jakarta'
+    annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
+    annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
+
     //redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     //test

--- a/e-commerce-project-study.git/cms/order-api/src/main/java/com/zerobase/cms/order/config/QueryDslConfig.java
+++ b/e-commerce-project-study.git/cms/order-api/src/main/java/com/zerobase/cms/order/config/QueryDslConfig.java
@@ -1,0 +1,18 @@
+package com.zerobase.cms.order.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/e-commerce-project-study.git/cms/order-api/src/main/java/com/zerobase/cms/order/controller/SearchController.java
+++ b/e-commerce-project-study.git/cms/order-api/src/main/java/com/zerobase/cms/order/controller/SearchController.java
@@ -1,0 +1,43 @@
+package com.zerobase.cms.order.controller;
+
+import com.zerobase.cms.order.domain.dto.ProductDto;
+import com.zerobase.cms.order.service.ProductSearchService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RestController
+@RequestMapping("/search")
+@RequiredArgsConstructor
+public class SearchController {
+
+    private final ProductSearchService productSearchService;
+
+    @GetMapping("/list")
+    public ResponseEntity<List<ProductDto>> searchByName(
+            @RequestParam String name) {
+
+        return ResponseEntity.ok(
+                productSearchService.searchByName(name)
+                        .stream()
+                        .map(ProductDto::noItemsfrom)
+                        .collect(Collectors.toList())
+                );
+    }
+
+    @GetMapping("/detail")
+    public ResponseEntity<ProductDto> searchDetail(
+            @RequestParam Long productId
+    ) {
+        return ResponseEntity.ok(ProductDto.from(
+                productSearchService.searchProduct(productId)
+            )
+        );
+    }
+}

--- a/e-commerce-project-study.git/cms/order-api/src/main/java/com/zerobase/cms/order/domain/dto/ProductDto.java
+++ b/e-commerce-project-study.git/cms/order-api/src/main/java/com/zerobase/cms/order/domain/dto/ProductDto.java
@@ -33,4 +33,13 @@ public class ProductDto {
                         .collect(Collectors.toList()))
                 .build();
     }
+
+    public static ProductDto noItemsfrom(ProductEntity productEntity) {
+        return ProductDto.builder()
+                .id(productEntity.getId())
+                .sellerId(productEntity.getSellerId())
+                .name(productEntity.getName())
+                .description(productEntity.getDescription())
+                .build();
+    }
 }

--- a/e-commerce-project-study.git/cms/order-api/src/main/java/com/zerobase/cms/order/domain/model/BaseEntity.java
+++ b/e-commerce-project-study.git/cms/order-api/src/main/java/com/zerobase/cms/order/domain/model/BaseEntity.java
@@ -1,0 +1,20 @@
+package com.zerobase.cms.order.domain.model;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(value = {AuditingEntityListener.class})
+public class BaseEntity {
+    @CreatedDate
+    private LocalDateTime createdAt;
+    @LastModifiedDate
+    private LocalDateTime modifiedAt;
+}

--- a/e-commerce-project-study.git/cms/order-api/src/main/java/com/zerobase/cms/order/domain/model/ProductEntity.java
+++ b/e-commerce-project-study.git/cms/order-api/src/main/java/com/zerobase/cms/order/domain/model/ProductEntity.java
@@ -1,7 +1,6 @@
 package com.zerobase.cms.order.domain.model;
 
 import com.zerobase.cms.order.domain.product.AddProductForm;
-import com.zerobase.cms.user.domain.model.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.envers.AuditOverride;

--- a/e-commerce-project-study.git/cms/order-api/src/main/java/com/zerobase/cms/order/domain/model/ProductItemEntity.java
+++ b/e-commerce-project-study.git/cms/order-api/src/main/java/com/zerobase/cms/order/domain/model/ProductItemEntity.java
@@ -1,7 +1,6 @@
 package com.zerobase.cms.order.domain.model;
 
 import com.zerobase.cms.order.domain.product.AddProductItemForm;
-import com.zerobase.cms.user.domain.model.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.envers.AuditOverride;

--- a/e-commerce-project-study.git/cms/order-api/src/main/java/com/zerobase/cms/order/domain/repository/ProductRepository.java
+++ b/e-commerce-project-study.git/cms/order-api/src/main/java/com/zerobase/cms/order/domain/repository/ProductRepository.java
@@ -8,7 +8,15 @@ import org.springframework.stereotype.Repository;
 import java.util.Optional;
 
 @Repository
-public interface ProductRepository extends JpaRepository<ProductEntity, Long>{
-    @EntityGraph(attributePaths = {"items"}, type = EntityGraph.EntityGraphType.LOAD)
+public interface ProductRepository extends JpaRepository<ProductEntity, Long>
+        , ProductRepositoryCustom{
+    @EntityGraph(attributePaths = {"items"}, type =
+            EntityGraph.EntityGraphType.LOAD)
     Optional<ProductEntity> findBySellerIdAndId(Long sellerId, Long productId);
+
+    @EntityGraph(attributePaths = {"items"}, type =
+            EntityGraph.EntityGraphType.LOAD)
+    Optional<ProductEntity> findWithItemsById(Long productId);
+
+
 }

--- a/e-commerce-project-study.git/cms/order-api/src/main/java/com/zerobase/cms/order/domain/repository/ProductRepositoryCustom.java
+++ b/e-commerce-project-study.git/cms/order-api/src/main/java/com/zerobase/cms/order/domain/repository/ProductRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.zerobase.cms.order.domain.repository;
+
+
+import com.zerobase.cms.order.domain.model.ProductEntity;
+
+import java.util.List;
+
+public interface ProductRepositoryCustom {
+    List<ProductEntity> searchByName(String name);
+}

--- a/e-commerce-project-study.git/cms/order-api/src/main/java/com/zerobase/cms/order/domain/repository/ProductRepositoryCustomImpl.java
+++ b/e-commerce-project-study.git/cms/order-api/src/main/java/com/zerobase/cms/order/domain/repository/ProductRepositoryCustomImpl.java
@@ -1,0 +1,25 @@
+package com.zerobase.cms.order.domain.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.zerobase.cms.order.domain.model.ProductEntity;
+import com.zerobase.cms.order.domain.model.QProductEntity;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class ProductRepositoryCustomImpl implements ProductRepositoryCustom{
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<ProductEntity> searchByName(String name) {
+
+        String searchName = "%" + name + "%";
+        QProductEntity product =  QProductEntity.productEntity;
+        return queryFactory.selectFrom(product)
+                .where(product.name.like(searchName)).fetch();
+    }
+}

--- a/e-commerce-project-study.git/cms/order-api/src/main/java/com/zerobase/cms/order/service/ProductSearchService.java
+++ b/e-commerce-project-study.git/cms/order-api/src/main/java/com/zerobase/cms/order/service/ProductSearchService.java
@@ -1,0 +1,32 @@
+package com.zerobase.cms.order.service;
+
+import com.zerobase.cms.order.domain.model.ProductEntity;
+import com.zerobase.cms.order.domain.repository.ProductRepository;
+import com.zerobase.cms.order.domain.repository.ProductRepositoryCustomImpl;
+import com.zerobase.cms.user.exception.CustomException;
+import com.zerobase.cms.user.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ProductSearchService {
+
+    private final ProductRepository productRepository;
+    private final ProductRepositoryCustomImpl productRepositoryCustom;
+
+    public List<ProductEntity> searchByName(String name) {
+        return productRepositoryCustom.searchByName(name);
+    }
+
+    public ProductEntity searchProduct(Long productId) {
+        return productRepository.findWithItemsById(productId).orElseThrow(
+                () -> new CustomException(ErrorCode.NOT_FOUND_PRODUCT)
+        );
+    }
+    public List<ProductEntity> getListByProductId(List<Long> productsId) {
+        return productRepository.findAllById(productsId);
+    }
+}

--- a/e-commerce-project-study.git/cms/user-api/build.gradle
+++ b/e-commerce-project-study.git/cms/user-api/build.gradle
@@ -40,7 +40,6 @@ dependencies {
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
 
-
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
     implementation 'com.mashape.unirest:unirest-java:1.4.9'
     implementation 'org.springframework.data:spring-data-envers'


### PR DESCRIPTION
Change
---
1. QueryDsl 라이브러리 활용하여 검색 기능 구현
2. 리스트 추출 시에는 하위 객체 출력 안하도록 구현
3. 상세검색 -> request parameter : id
4. 리스트검색 -> request parameter : name

Background
---
- ProductEntity, ProductItemEntity가 BaseEntity(user-api 모듈)를 상속받고 있는데, QClass 생성 시 다른 모듈에 있는 부모 클래스를 생성하지 못하는 것으로 보임. 따라서 order-api에 BaseEntity를 추가 생성. 
